### PR TITLE
Improved performance on setups where git is aliased to hub command.

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -83,7 +83,7 @@ k () {
     if [[ -L $NAME ]]; then   IS_SYMLINK=true; fi
 
     # is this a git repo
-    if [[ $k == 1 && $(git rev-parse --is-inside-work-tree 2>/dev/null) == true ]]
+    if [[ $k == 1 && $(command git rev-parse --is-inside-work-tree 2>/dev/null) == true ]]
       then
       IS_GIT_REPO=true
     fi;
@@ -197,7 +197,7 @@ k () {
       then
       if [[ -d $NAME"/.git" ]] # if contains a git folder
         then
-        if git --git-dir=`pwd`/$NAME/.git --work-tree=`pwd`/$NAME diff --quiet --ignore-submodules HEAD &>/dev/null # if dirty
+        if command git --git-dir=`pwd`/$NAME/.git --work-tree=`pwd`/$NAME diff --quiet --ignore-submodules HEAD &>/dev/null # if dirty
           then REPOMARKER="\033[0;32m|\033[0m" # Show a green vertical bar for dirty
           else REPOMARKER="\033[0;31m|\033[0m" # Show a red vertical bar if clean
         fi
@@ -206,7 +206,7 @@ k () {
 
     if [[ $IS_GIT_REPO == true && $k != 1 && $k != 2 && $NAME != '.git' ]]
       then
-      STATUS=$(git status --porcelain --ignored --untracked-files="normal" $NAME);
+      STATUS=$(command git status --porcelain --ignored --untracked-files="normal" $NAME);
       STATUS=$STATUS[1,2]
         if [[ $STATUS == ' M' ]]; then REPOMARKER="\033[0;31m|\033[0m";     # Modified
       elif [[ $STATUS == '??' ]]; then REPOMARKER="\033[38;5;214m|\033[0m"; # Untracked


### PR DESCRIPTION
People who use `hub` command have their `git` aliased to `hub` and this slows down scripts a lot.

I added the `command` before `git` calls so Zsh will call non aliased `git` which removes performance hit added by `hub`.
