### PR TITLE
Added -- to escape hyphens in filename for zstat

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -74,7 +74,7 @@ k () {
   do
     statvar="stats_$i"
     typeset -A $statvar
-    zstat -H $statvar -Lsn -F "%s^%d^%b^%H:%M^%Y" "$fn"  # use lstat, render mode/uid/gid to strings
+    zstat -H $statvar -Lsn -F "%s^%d^%b^%H:%M^%Y" -- "$fn"  # use lstat, render mode/uid/gid to strings
     STATS_PARAMS_LIST+=($statvar)
     TOTAL_BLOCKS+=${statvar[blocks]}
     i+=1


### PR DESCRIPTION
Fixes #14

Add `--` causes zsh to ignore any future options to the command. Perfect for escaping hyphens.

I tested in OSX and Debain.
