### PR TITLE
Added spaces for month that have different length sizes

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -214,9 +214,9 @@ k () {
 
     # Format date to show year if more than 6 months since last modified
     if (( TIME_DIFF < 15724800 )); then
-      DATE_OUTPUT="${DATE[2]} ${DATE[3]} ${DATE[4]}"
+      DATE_OUTPUT="${DATE[2]} ${(r:5:: :)${DATE[3][0,5]}} ${DATE[4]}"
     else
-      DATE_OUTPUT="${DATE[2]} ${DATE[3]}  ${DATE[5]}"  # extra space; 4 digit year instead of 5 digit HH:MM
+      DATE_OUTPUT="${DATE[2]} ${(r:6:: :)${DATE[3][0,5]}} ${DATE[5]}"  # extra space; 4 digit year instead of 5 digit HH:MM
     fi;
     DATE_OUTPUT[1]="${DATE_OUTPUT[1]//0/ }" # If day of month begins with zero, replace zero with space
 


### PR DESCRIPTION
Not sure how it is in english but in french we have different sizes for month abreviation, e.g. : déc. for december and sept. for september.
So, after months information is not aligned
rw-r--r--   1 mattboll mattboll    1151535 13 déc. 09:58   auie.jpg
-rw-r--r--   1 mattboll mattboll     370081   7 sept. 17:46   zoub.pdf
