### PR TITLE
Reuse $LS_COLORS via direct ls call

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -408,13 +408,8 @@ k () {
       # But we don't want to quote '.'; so instead we escape the escape manually and use q-
       NAME="${${NAME##*/}//$'\e'/\\e}"    # also propagate changes to SYMLINK_TARGET below
 
-      if (( IS_DIRECTORY ))
-      then
-        NAME=$'\e[38;5;32m'"$NAME"$'\e[0m'
-      elif (( IS_SYMLINK ))
-      then
-        NAME=$'\e[0;35m'"$NAME"$'\e[0m'
-      fi
+      # Call ls so it's possible to reuse $LS_COLORS (with GNU coreutils) or $LSCOLORS (with BSD)
+      NAME=$(command ls --color -d -1 $NAME 2>/dev/null || command ls -G -d -1 $NAME 2>/dev/null)
 
       # --------------------------------------------------------------------------
       # Format symlink target


### PR DESCRIPTION
This allows to use properly set LS_COLORS environment variable. This is how it looks like with [seebi/dircolors-solarized](https://github.com/seebi/dircolors-solarized):
![dircolors](https://cloud.githubusercontent.com/assets/787519/7769463/98ee3b92-008c-11e5-815d-5983c8aa88c1.png)

This might hurt performance a bit, but I'm not sure whether manual parsing of LS_COLORS will be any faster.

Closes #19.
