### PR TITLE
Use builtin cd, fixes #56, enhancd compatability

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -285,8 +285,8 @@ k () {
         GIT_TOPLEVEL=''
       else
         if (( IS_DIRECTORY ));
-          then cd -q $NAME     2>/dev/null || cd -q - >/dev/null && IS_GIT_REPO=0 #Say no if we don't have permissions there
-          else cd -q $NAME:a:h 2>/dev/null || cd -q - >/dev/null && IS_GIT_REPO=0
+          then builtin cd -q $NAME     2>/dev/null || builtin cd -q - >/dev/null && IS_GIT_REPO=0 #Say no if we don't have permissions there
+          else builtin cd -q $NAME:a:h 2>/dev/null || builtin cd -q - >/dev/null && IS_GIT_REPO=0
         fi
         if [[ $(command git rev-parse --is-inside-work-tree 2>/dev/null) == true ]]; then
           IS_GIT_REPO=1
@@ -294,7 +294,7 @@ k () {
         else
           IS_GIT_REPO=0
         fi
-        cd -q - >/dev/null
+        builtin cd -q - >/dev/null
       fi
 
       # Get human readable output if necessary


### PR DESCRIPTION
Since `command` requires POSIX_BUILTINS, how about using `builtin`?
