### PR TITLE
Fix directory name display when MARK_DIRS is set

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -472,9 +472,12 @@ k () {
       # --------------------------------------------------------------------------
       # Unfortunately, the choices for quoting which escape ANSI color sequences are q & qqqq; none of q- qq qqq work.
       # But we don't want to quote '.'; so instead we escape the escape manually and use q-
-      NAME="${${NAME##*/}//$'\e'/\\e}"    # also propagate changes to SYMLINK_TARGET below
+      NAME="${${${NAME%/}##*/}//$'\e'/\\e}"    # also propagate changes to SYMLINK_TARGET below
 
         if [[ $IS_DIRECTORY         == 1 ]]; then
+          if [[ $options[mark_dirs] == on ]]; then
+            NAME="${NAME}/"
+          fi
           if [[ $IS_WRITABLE_BY_OTHERS == 1 ]]; then
             if [[ $HAS_STICKY_BIT == 1 ]]; then
               NAME=$'\e['"$K_COLOR_TW"'m'"$NAME"$'\e[0m';


### PR DESCRIPTION
The expansion pattern ${NAME##*/} is used to retrieve the last part of a path.
Unfortunately, if NAME represents the path to a directory and the MARK_DIRS
option is set, this will end up deleting everything in NAME, as a forward slash
is the last character in the string, resulting in nothing being displayed for
the directory name.

To work around this, the trailing slash is deleted if it's there, then added
back in if the option is set.

Fixes #63, I think?
