### PR TITLE
Adjust plugin.zsh file to run on zsh 5.1 in mSYS2

### DIFF
--- a/k.plugin.zsh
+++ b/k.plugin.zsh
@@ -1,1 +1,1 @@
-k.sh
+source ${0:A:h}/k.sh


### PR DESCRIPTION
mSYS2 on Windows doesn't support symlinks so I have changed the plugin.zsh to be a normal file for it to work. Probably noone apart of me uses 'k' on windows but it works great after this one little change.
