### PR TITLE
Add missing `IS_WRITABLE_BY_OTHERS=0`

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -306,6 +306,7 @@ k () {
       HAS_UID_BIT=0
       HAS_GID_BIT=0
       HAS_STICKY_BIT=0
+      IS_WRITABLE_BY_OTHERS=0
 
          PERMISSIONS="${sv[mode]}"
        HARDLINKCOUNT="${sv[nlink]}"


### PR DESCRIPTION
Previously, each file status variable is reset appropriately except for `IS_WRITABLE_BY_OTHERS`.  This PR fixes that.
