### PR TITLE
Fix $base_dir leak

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -85,6 +85,7 @@ k () {
 
   # Setup array of directories to print
   typeset -a base_dirs
+  typeset base_dir
 
   if [[ "$@" == "" ]]; then
     base_dirs=.


### PR DESCRIPTION
## Issue

`$base_dir` is set after running `k`.

``` sh
k $PWD
echo $base_dir
cd ~base_dir
```
## Changes

`typeset` the variable to keep it scoped
