### PR TITLE
Add options for sort order

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -11,12 +11,14 @@ k () {
   setopt local_options null_glob typeset_silent no_auto_pushd nomarkdirs
 
   # Process options and get files/directories
-  typeset -a o_all o_almost_all o_human o_si o_directory o_no_directory o_no_vcs o_sort o_sort_reverse o_help
+  typeset -a o_all o_almost_all o_human o_si o_directory o_group_directories \
+	  o_no_directory o_no_vcs o_sort o_sort_reverse o_help
   zparseopts -E -D \
              a=o_all -all=o_all \
              A=o_almost_all -almost-all=o_almost_all \
              c=o_sort \
              d=o_directory -directory=o_directory \
+	     -group-directories-first=o_group_directories \
              h=o_human -human=o_human \
              -si=o_si \
              n=o_no_directory -no-directory=o_no_directory \
@@ -79,6 +81,9 @@ k () {
     typeset SORT_GLOB="${S_ORD}${SPEC}"
   else
     typeset SORT_GLOB="${R_ORD}${SPEC}"
+  fi
+  if [[ "$o_group_directories" != "" ]]; then
+    SORT_GLOB="oe:[[ -d \$REPLY ]];REPLY=\$?:$SORT_GLOB"
   fi
 
   # Check which numfmt available (if any), warn user if not available

--- a/k.sh
+++ b/k.sh
@@ -11,15 +11,22 @@ k () {
   setopt local_options null_glob typeset_silent no_auto_pushd nomarkdirs
 
   # Process options and get files/directories
-  typeset -a o_all o_almost_all o_human o_si o_directory o_no_directory o_no_vcs o_help
+  typeset -a o_all o_almost_all o_human o_si o_directory o_no_directory o_no_vcs o_sort o_sort_reverse o_help
   zparseopts -E -D \
              a=o_all -all=o_all \
              A=o_almost_all -almost-all=o_almost_all \
+             c=o_sort \
              d=o_directory -directory=o_directory \
              h=o_human -human=o_human \
              -si=o_si \
              n=o_no_directory -no-directory=o_no_directory \
              -no-vcs=o_no_vcs \
+             r=o_sort_reverse -reverse=o_sort_reverse \
+             -sort:=o_sort \
+             S=o_sort \
+             t=o_sort \
+             u=o_sort \
+             U=o_sort \
              -help=o_help
 
   # Print Help if bad usage, or they asked for it
@@ -29,10 +36,19 @@ k () {
     print -u2 "Options:"
     print -u2 "\t-a      --all           list entries starting with ."
     print -u2 "\t-A      --almost-all    list all except . and .."
+    print -u2 "\t-c                      sort by ctime (inode change time)"
     print -u2 "\t-d      --directory     list only directories"
     print -u2 "\t-n      --no-directory  do not list directories"
     print -u2 "\t-h      --human         show filesizes in human-readable format"
     print -u2 "\t        --si            with -h, use powers of 1000 not 1024"
+    print -u2 "\t-r      --reverse       reverse sort order"
+    print -u2 "\t-S                      sort by size"
+    print -u2 "\t-t                      sort by time (modification time)"
+    print -u2 "\t-u                      sort by atime (use or access time)"
+    print -u2 "\t-U                      Unsorted"
+    print -u2 "\t        --sort WORD     sort by WORD: none (U), size (S),"
+    print -u2 "\t                        time (t), ctime or status (c),"
+    print -u2 "\t       		 atime or access or use (u)"
     print -u2 "\t        --no-vcs        do not get VCS status (much faster)"
     print -u2 "\t        --help          show this help"
     return 1
@@ -42,6 +58,27 @@ k () {
   if [[ "$o_directory" != "" && "$o_no_directory" != "" ]]; then
     print -u2 "$o_directory and $o_no_directory cannot be used together"
     return 1
+  fi
+
+  # case is like a mnemonic for sort order:
+  # lower-case for standard, upper-case for descending
+  local S_ORD="o" R_ORD="O" SPEC="n"  # default: by name
+
+  # translate ls options to glob-qualifiers,
+  # ignoring "--sort" prefix of long-args form
+  case ${o_sort:#--sort} in
+    -U|none)                     SPEC="N";;
+    -t|time)                     SPEC="m";;
+    -c|ctime|status)             SPEC="c";;
+    -u|atime|access|use)         SPEC="a";;
+    # reverse default order for sort by size
+    -S|size) S_ORD="O" R_ORD="o" SPEC="L";;
+  esac
+
+  if [[ "$o_sort_reverse" == "" ]]; then
+    typeset SORT_GLOB="${S_ORD}${SPEC}"
+  else
+    typeset SORT_GLOB="${R_ORD}${SPEC}"
   fi
 
   # Check which numfmt available (if any), warn user if not available
@@ -220,21 +257,21 @@ k () {
 
       if [[ "$o_all" != "" || "$o_almost_all" != "" ]]; then
         if [[ "$o_directory" != "" ]]; then
-          show_list+=($base_dir/*(D/))
+          show_list+=($base_dir/*(D/$SORT_GLOB))
         elif [[ "$o_no_directory" != "" ]]; then
           #Use (^/) instead of (.) so sockets and symlinks get displayed
-          show_list+=($base_dir/*(D^/))
+          show_list+=($base_dir/*(D^/$SORT_GLOB))
         else
-          show_list+=($base_dir/*(D))
+          show_list+=($base_dir/*(D$SORT_GLOB))
         fi
       else
         if [[ "$o_directory" != "" ]]; then
-          show_list+=($base_dir/*(/))
+          show_list+=($base_dir/*(/$SORT_GLOB))
         elif [[ "$o_no_directory" != "" ]]; then
           #Use (^/) instead of (.) so sockets and symlinks get displayed
-          show_list+=($base_dir/*(^/))
+          show_list+=($base_dir/*(^/$SORT_GLOB))
         else
-          show_list+=($base_dir/*)
+	  show_list+=($base_dir/*($SORT_GLOB))
         fi
       fi
     fi


### PR DESCRIPTION
Sort options are as per ls, except:
-Version and extension sort not implemented due to lack of a direct glob sort equivalent, should they be desired in future they can be added to current implementation via either oe and lambda or o+ and function qualifiers.
-Long-form time args can be passed directly after --sort (ls requires: --sort=time --time=long-arg-name)   
-Long args will override flags if both are used (ls: last-seen wins)
Sort order applies within directory args, not between the args themselves.