### PR TITLE
Workaround zsh/stat bug causing garbage display with utf characters

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -294,7 +294,7 @@ k () {
     do
       statvar="stats_$i"
       typeset -A $statvar
-      zstat -H $statvar -Lsn -F "%s^%d^%b^%H:%M^%Y" -- "$fn"  # use lstat, render mode/uid/gid to strings
+      LC_TIME=C zstat -H $statvar -Lsn -F "%s^%d^%b^%H:%M^%Y" -- "$fn"  # use lstat, render mode/uid/gid to strings
       STATS_PARAMS_LIST+=($statvar)
       i+=1
     done


### PR DESCRIPTION
zstat isn't probably able to render UTF characters returned from strftime. There
is abbreviated month name respecting locales setting used in format string.

It would be great to fix this somehow in ZSH, but for now using English locales
seams to be reasonable workaround. English abbr. month looks better in output
then month number.

You can problem in attached picture. First rectangle shows wrong encoding/display issue, second is how it should be displayed (and is also confirming that my terminal is utf capable ;) )

![k_zstat_locale_problem](https://user-images.githubusercontent.com/105303/46231791-82510700-c36d-11e8-9baa-5f1d96b74380.png)
