### PR TITLE
[WIP] Implement conditional highlighting of permissions, user and group

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -453,7 +453,6 @@ k () {
             # Permissions User
             if (( UID == nsv[uid] )); then
               PER1="${PERMISSIONS[2,4]}"
-              PER1="${PERMISSIONS[2,4]//(#m)[\-]/$color$MATCH$reset}"
             else
               PER1="$color${PERMISSIONS[2,4]}$reset"
             fi
@@ -461,13 +460,11 @@ k () {
             # Permissions Group
             if (( usergroups[(r)${nsv[gid]}] )); then
               PER2="${PERMISSIONS[5,7]}"
-              PER2="${PERMISSIONS[5,7]//(#m)[\-]/$color$MATCH$reset}"
             else
               PER2="$color${PERMISSIONS[5,7]}$reset"
             fi
-
             # Permissions Other
-            PER3="${PERMISSIONS[8,10]//(#m)[\-]/$color$MATCH$reset}"
+            PER3="${PERMISSIONS[8,10]}"
 
             PERMISSIONS_OUTPUT="$FILETYPE$PER1$PER2$PER3"
           ;;


### PR DESCRIPTION
Two methods, currently set by `K_PERM_COLOR`
- absolute: u ⇒ green, g ⇒ yellow, o ⇒ red (same as [grc](https://github.com/garabik/grc))
- relative: u,g ⇒ fade if user doesn't have UID/GID

This PR also:
- Only fades the owner and group if the UID and GID matches
- colors all link permissions with `K_COLOR_LN`, since they don't have any bearing on the actual permissions used.

Unfortunate consequences of the methods I used:
- Runs zstat a second time on every file, to get numeric values for uid and gid. (OTOH, this does bring up possibilities for using numeric values elsewhere for speed. date/time methods especially)
- Uses a few temp variables to do add color in the ${string//match/replacement}

If there is interest, I would be happy to change things, clean this up, split this it up atomically, get it merge-ready.

![Demo screenshot](https://i.imgur.com/gLekPk3.png)