### PR TITLE
Allow custom colors in Linux

### DIFF
--- a/k.sh
+++ b/k.sh
@@ -150,7 +150,7 @@ k () {
   K_COLOR_SG="30;46" # sg:executable with setgid bit set
   K_COLOR_TW="30;42" # tw:directory writable to others, with sticky bit
   K_COLOR_OW="30;43" # ow:directory writable to others, without sticky bit
-  K_COLOR_BR="0;30"  # branch
+  K_COLOR_BR="${K_COLOR_BR:-0;30}"  # branch
 
   # read colors if osx and $LSCOLORS is defined
   if [[ $(uname) == 'Darwin' && -n $LSCOLORS ]]; then

--- a/k.sh
+++ b/k.sh
@@ -169,9 +169,46 @@ k () {
   fi
 
   # read colors if linux and $LS_COLORS is defined
-  # if [[ $(uname) == 'Linux' && -n $LS_COLORS ]]; then
-
-  # fi
+  if [[ $(uname) == 'Linux' && -n $LS_COLORS ]]; then
+    for val in $(echo $LS_COLORS | awk 'BEGIN {RS=":"} {print $1}'); do
+      IFS='=' read -r -A array <<< "$val"
+      case ${array[1]} in
+        di)
+          K_COLOR_DI="${array[2]}"
+          ;;
+        ln)
+          K_COLOR_LN="${array[2]}"
+          ;;
+        so)
+          K_COLOR_SO="${array[2]}"
+          ;;
+        pi)
+          K_COLOR_PI="${array[2]}"
+          ;;
+        ex)
+          K_COLOR_EX="${array[2]}"
+          ;;
+        bd)
+          K_COLOR_BD="${array[2]}"
+          ;;
+        cd)
+          K_COLOR_CD="${array[2]}"
+          ;;
+        su)
+          K_COLOR_SU="${array[2]}"
+          ;;
+        sg)
+          K_COLOR_SG="${array[2]}"
+          ;;
+        tw)
+          K_COLOR_TW="${array[2]}"
+          ;;
+        ow)
+          K_COLOR_OW="${array[2]}"
+          ;;
+      esac
+    done
+  fi
 
   # ----------------------------------------------------------------------------
   # Loop over passed directories and files to display


### PR DESCRIPTION
The default color scheme does not work very well on some backgrounds.

This change would:
- Read color values from `$LS_COLORS`  in Linux.
- Allow branch color to be overridden using an environment variable.