### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,14 @@ Then load as a plugin in your `.zshrc`
 plugins+=(k)
 ```
 
+### Using [Fig](https://fig.io)
+
+Fig adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `k` in just one click.
+
+<a href="https://fig.io/plugins/other/k" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### Manually
 Clone this repository somewhere (~/k for example)
 


### PR DESCRIPTION
We recently listed this plugin on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig listed as a download method on your readme. We have over 100k users that will benefit from this. 

Thanks so much and please let me know if you have any questions!

