### PR TITLE
Add `sed` cmd to `oh-my-zsh` install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,10 +66,10 @@ Clone k into your custom plugins repo
 ```shell
 git clone https://github.com/supercrabtree/k $ZSH_CUSTOM/plugins/k
 ```
-Then load as a plugin in your `.zshrc`
+Then load as a plugin in your `.zshrc`. If `plugins` is where it usually is:
 
 ```shell
-plugins+=(k)
+sed -i 's/^plugins=(/plugins=(k /g' $HOME/.zshrc
 ```
 
 ### Manually


### PR DESCRIPTION
This docs-only PR swaps out the `plugins+=(k)` syntax in the section on [installing with Oh My ZSH!](https://github.com/supercrabtree/k#as-an-oh-my-zsh-custom-plugin) with a `sed` command which works in the most common use case to add `k` to the `plugins` variable.

Most users run ZSH with their file in the default location, so having a command they can copy and paste directly into a terminal is quite helpful.